### PR TITLE
Fix crash when there are no parseable releases

### DIFF
--- a/src/ChangelogParser.php
+++ b/src/ChangelogParser.php
@@ -50,10 +50,11 @@ class ChangelogParser
 
         $changelog = Changelog::make($title, $description);
 
-        $unreleased = $this->parseRelease();
-        $unreleased && Str::startsWith(Str::lower($unreleased->title), ['unreleased', '[unreleased'])
-            ? $changelog->setUnreleased($unreleased)
-            : $changelog->addRelease($unreleased);
+        if ($unreleased = $this->parseRelease()) {
+            Str::startsWith(Str::lower($unreleased->title), ['unreleased', '[unreleased'])
+                ? $changelog->setUnreleased($unreleased)
+                : $changelog->addRelease($unreleased);
+        }
 
         while ($release = $this->parseRelease()) {
             $changelog->addRelease($release);

--- a/tests/ChangelogParserTest.php
+++ b/tests/ChangelogParserTest.php
@@ -33,4 +33,13 @@ class ChangelogParserTest extends TestCase
             ['inertia.md'],
         ];
     }
+
+    /** @test */
+    public function it_parses_a_changelog_without_any_releases(): void
+    {
+        $this->assertSame(
+            $this->loadFixture('empty-changelog-default-title-default-description-unreleased-header.md'),
+            (string) ChangelogParser::parse($this->loadFixture('empty-changelog-default-title-default-description.md')),
+        );
+    }
 }

--- a/tests/_fixtures/empty-changelog-default-title-default-description.md
+++ b/tests/_fixtures/empty-changelog-default-title-default-description.md
@@ -1,0 +1,6 @@
+# Changelog
+
+All notable changes to this project will be documented in this file.
+
+The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
+and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).


### PR DESCRIPTION
When a changelog does not have any releases, the parser would try to add a `NULL`-release to the Changelog instance. This PR fixes that issue.