### PR TITLE
Fix issue #9: Data loss with duplicate sections

### DIFF
--- a/src/Components/Release.php
+++ b/src/Components/Release.php
@@ -35,7 +35,16 @@ class Release implements Stringable
 
     public function addSection(Section $section): self
     {
-        $this->sections->put($section->title, $section);
+        // if the section already exists, append the entries to it
+        if ($this->sections->has($section->title)) {
+            $existingSection = $this->sections->get($section->title);
+            $existingSection->appendSection($section);
+
+            return $this;
+        }
+        else {
+            $this->sections->put($section->title, $section);
+        }
 
         return $this;
     }

--- a/src/Components/Section.php
+++ b/src/Components/Section.php
@@ -20,6 +20,13 @@ class Section implements Stringable
         return new static($title);
     }
 
+    public function appendSection(Section $section): self
+    {
+        $this->entries = array_merge($this->entries, $section->entries);
+
+        return $this;
+    }
+
     public function addEntry(Entry|string $title, string|null $url = null): self
     {
         $this->entries[] = $title instanceof Entry

--- a/tests/ChangelogTest.php
+++ b/tests/ChangelogTest.php
@@ -151,4 +151,21 @@ class ChangelogTest extends TestCase
             (string) $changelogA
         );
     }
+
+    /** @test */
+    public function it_can_reconcile_duplicate_sections_on_change(): void
+    {
+        $changeLogWithDup = ChangelogParser::parse($this->loadFixture('changelog-with-duplicate-added.md'));
+
+        $changeLogWithDup->unreleased()->section('changed')->addEntry(Entry::make('New change'));
+
+        $expected = $this->loadFixture('changelog-with-duplicate-added-changed.md');
+        $actual = (string) $changeLogWithDup;
+
+        // Normalize line endings for comparison
+        $expected = str_replace(["\r\n", "\r"], "\n", $expected);
+        $actual = str_replace(["\r\n", "\r"], "\n", $actual);
+
+        $this->assertSame($expected, $actual);
+    }
 }

--- a/tests/_fixtures/changelog-with-duplicate-added-changed.md
+++ b/tests/_fixtures/changelog-with-duplicate-added-changed.md
@@ -1,0 +1,22 @@
+# Changelog
+
+All notable changes to this project will be documented in this file.
+
+The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
+and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
+
+## [Unreleased]
+
+### Added
+
+- Added something
+- Added something else but made a new section by mistake
+
+### Fixed
+
+- Fixed something
+
+### Changed
+
+- Made a change
+- New change

--- a/tests/_fixtures/changelog-with-duplicate-added.md
+++ b/tests/_fixtures/changelog-with-duplicate-added.md
@@ -1,0 +1,24 @@
+# Changelog
+
+All notable changes to this project will be documented in this file.
+
+The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
+and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
+
+## [Unreleased]
+
+### Changed
+
+- Made a change
+
+### Added
+
+- Added something
+
+### Fixed
+
+- Fixed something
+
+### Added
+
+- Added something else but made a new section by mistake


### PR DESCRIPTION
 - When processing an incorrectly formatted changelog with duplicate sections only the contents of the last section was retained. This could easily be missed by clients. This change avoids that problem by appending the contents of any duplicated sections into the first section processed.